### PR TITLE
feat(game): implement attack mechanism with real-time moves

### DIFF
--- a/CSC710_Battleship_Technical_Document.md
+++ b/CSC710_Battleship_Technical_Document.md
@@ -68,8 +68,8 @@ A real-time, browser-based multiplayer Battleship game where players can join a 
 | Carrier | 5 |
 | Battleship | 4 |
 | Cruiser | 3 |
-| Submarine | 3 |
-| Destroyer | 2 |
+| Submarine | 2 |
+| Destroyer | 1 |
 
 - Ships can be placed horizontally or vertically, but cannot overlap or go out of bounds.
 - Players alternate turns, each selecting one cell on the opponent's grid.
@@ -381,8 +381,8 @@ flowchart TD
 │   A B C D E F G H I J       │   ☐ Carrier (5)       │
 │ 1 . . . . . . . . . .       │   ☐ Battleship (4)    │
 │ 2 . . . . . . . . . .       │   ☐ Cruiser (3)       │
-│ 3 . . . . . . . . . .       │   ☐ Submarine (3)     │
-│ 4 . . . . . . . . . .       │   ☐ Destroyer (2)     │
+│ 3 . . . . . . . . . .       │   ☐ Submarine (2)     │
+│ 4 . . . . . . . . . .       │   ☐ Destroyer (1)     │
 │ 5 . . . . . . . . . .       │                       │
 │ 6 . . . . . . . . . .       │   [Rotate Ship]       │
 │ 7 . . . . . . . . . .       │   [Random Place]      │
@@ -1169,8 +1169,8 @@ const SHIP_SIZES: Record<string, number> = {
   carrier: 5,
   battleship: 4,
   cruiser: 3,
-  submarine: 3,
-  destroyer: 2,
+  submarine: 2,
+  destroyer: 1,
 };
 
 function validatePlacement(ships: Ship[]): boolean {

--- a/src/components/game/GameEndModal.tsx
+++ b/src/components/game/GameEndModal.tsx
@@ -1,0 +1,40 @@
+import { useNavigate } from "react-router";
+import { Modal } from "../common/Modal";
+
+interface GameEndModalProps {
+  isOpen: boolean;
+  isWinner: boolean;
+  opponentName: string;
+}
+
+export function GameEndModal({
+  isOpen,
+  isWinner,
+  opponentName,
+}: GameEndModalProps) {
+  const navigate = useNavigate();
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={() => navigate("/lobby")}
+      title={isWinner ? "Victory!" : "Defeat"}
+    >
+      <div className="flex flex-col items-center gap-4 py-2">
+        <span className="text-5xl">{isWinner ? "🎉" : "💥"}</span>
+        <p className="text-center text-slate-200">
+          {isWinner
+            ? `You sank all of ${opponentName}'s ships!`
+            : `${opponentName} sank all your ships.`}
+        </p>
+        <button
+          type="button"
+          onClick={() => navigate("/lobby")}
+          className="mt-2 rounded-lg bg-blue-600 px-6 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-500"
+        >
+          Return to Lobby
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/game/TurnIndicator.tsx
+++ b/src/components/game/TurnIndicator.tsx
@@ -1,0 +1,20 @@
+interface TurnIndicatorProps {
+  isMyTurn: boolean;
+  opponentName: string;
+}
+
+export function TurnIndicator({ isMyTurn, opponentName }: TurnIndicatorProps) {
+  if (isMyTurn) {
+    return (
+      <div className="rounded-lg border border-emerald-500/40 bg-emerald-950/30 px-4 py-2.5 text-center text-sm font-semibold text-emerald-300">
+        Your Turn — Click a cell to fire!
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-amber-500/40 bg-amber-950/30 px-4 py-2.5 text-center text-sm font-semibold text-amber-300">
+      Waiting for {opponentName}...
+    </div>
+  );
+}

--- a/src/game/shipRules.ts
+++ b/src/game/shipRules.ts
@@ -1,15 +1,41 @@
-import type { Coordinate, Orientation } from "../types";
+import type { Coordinate, Orientation, ShipType } from "../types";
 
 export const MIN_SHIP_COUNT = 1;
 export const MAX_SHIP_COUNT = 5;
 export const BOARD_SIZE = 10;
 
+const SHIP_TYPE_BY_SIZE: Record<number, ShipType> = {
+  1: "destroyer",
+  2: "submarine",
+  3: "cruiser",
+  4: "battleship",
+  5: "carrier",
+};
+
+const SHIP_NAME_BY_SIZE: Record<number, string> = {
+  1: "Destroyer",
+  2: "Submarine",
+  3: "Cruiser",
+  4: "Battleship",
+  5: "Carrier",
+};
+
+export function getShipType(size: number): ShipType {
+  return SHIP_TYPE_BY_SIZE[size] ?? "destroyer";
+}
+
+export function getShipName(size: number): string {
+  return SHIP_NAME_BY_SIZE[size] ?? `Ship-${size}`;
+}
+
 export interface MatchShip {
   id: string;
+  type: ShipType;
   size: number;
   hits: number;
   sunk: boolean;
   cells: Coordinate[];
+  orientation: Orientation;
 }
 
 /**
@@ -31,10 +57,12 @@ export function getFleetSizes(shipCount: number): number[] {
 export function createFleetState(shipCount: number): MatchShip[] {
   return getFleetSizes(shipCount).map((size, index) => ({
     id: `ship-${index + 1}`,
+    type: getShipType(size),
     size,
     hits: 0,
     sunk: false,
-    cells: []
+    cells: [],
+    orientation: "horizontal" as Orientation,
   }));
 }
 

--- a/src/hooks/useGame.ts
+++ b/src/hooks/useGame.ts
@@ -1,0 +1,366 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import { supabase } from "../lib/supabase";
+import { useAuth } from "./useAuth";
+import type { RealtimeChannel } from "@supabase/supabase-js";
+import type {
+  Game,
+  GamePlayer,
+  GameStatus,
+  Move,
+  CellState,
+  BoardState,
+} from "../types";
+import type { MatchShip } from "../game/shipRules";
+import {
+  convertFleetToBoard,
+  resolveAttack,
+  checkWinByMoves,
+  buildOpponentDisplay,
+  buildMyDisplay,
+  emptyBoard,
+} from "../lib/gameLogic";
+
+interface PlayerInfo {
+  id: string;
+  displayName: string;
+}
+
+export interface UseGameReturn {
+  gameStatus: GameStatus;
+  isMyTurn: boolean;
+  myBoard: CellState[][];
+  opponentBoard: CellState[][];
+  myInfo: PlayerInfo | null;
+  opponentInfo: PlayerInfo | null;
+  myPlayer: GamePlayer | null;
+  winnerId: string | null;
+  loading: boolean;
+  error: string | null;
+  submitReady: (fleet: MatchShip[]) => Promise<void>;
+  attack: (row: number, col: number) => Promise<void>;
+}
+
+export function useGame(gameId: string | undefined): UseGameReturn {
+  const { user } = useAuth();
+
+  const [game, setGame] = useState<Game | null>(null);
+  const [myPlayer, setMyPlayer] = useState<GamePlayer | null>(null);
+  const [opponentPlayer, setOpponentPlayer] = useState<GamePlayer | null>(null);
+  const [moves, setMoves] = useState<Move[]>([]);
+  const [myInfo, setMyInfo] = useState<PlayerInfo | null>(null);
+  const [opponentInfo, setOpponentInfo] = useState<PlayerInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const channelRef = useRef<RealtimeChannel | null>(null);
+  // Prevent duplicate attack processing
+  const attackingRef = useRef(false);
+
+  const gameStatus: GameStatus = game?.status ?? "setup";
+  const isMyTurn = game?.current_turn === user?.id && gameStatus === "in_progress";
+  const winnerId = game?.winner_id ?? null;
+
+  // Derive board displays from state
+  const myMoves = moves.filter((m) => m.player_id === user?.id);
+  const opponentMoves = moves.filter((m) => m.player_id !== user?.id);
+
+  const myBoard: CellState[][] =
+    myPlayer?.board && myPlayer.board.ships.length > 0
+      ? buildMyDisplay(myPlayer.board, opponentMoves)
+      : emptyBoard();
+
+  const opponentBoard: CellState[][] =
+    gameStatus === "in_progress" || gameStatus === "finished"
+      ? buildOpponentDisplay(myMoves, opponentPlayer?.board ?? undefined)
+      : emptyBoard();
+
+  // ── Initial data fetch ──────────────────────────────────────────────
+  useEffect(() => {
+    if (!gameId || !user) return;
+    const userId = user.id;
+    let cancelled = false;
+
+    async function fetchGameData() {
+      try {
+        // Fetch game, players, and moves in parallel
+        const [gameRes, playersRes, movesRes] = await Promise.all([
+          supabase.from("games").select("*").eq("id", gameId).single(),
+          supabase.from("games_players").select("*").eq("game_id", gameId),
+          supabase.from("moves").select("*").eq("game_id", gameId).order("move_number", { ascending: true }),
+        ]);
+
+        if (cancelled) return;
+
+        if (gameRes.error) throw new Error(gameRes.error.message);
+        if (playersRes.error) throw new Error(playersRes.error.message);
+
+        const gameData = gameRes.data as Game;
+        const playersData = (playersRes.data ?? []) as GamePlayer[];
+        const movesData = (movesRes.data ?? []) as Move[];
+
+        setGame(gameData);
+        setMoves(movesData);
+
+        const me = playersData.find((p) => p.player_id === userId) ?? null;
+        const opp = playersData.find((p) => p.player_id !== userId) ?? null;
+        setMyPlayer(me);
+        setOpponentPlayer(opp);
+
+        // Fetch profiles for display names
+        const playerIds = playersData.map((p) => p.player_id);
+        if (playerIds.length > 0) {
+          const { data: profiles } = await supabase
+            .from("profiles")
+            .select("id, display_name")
+            .in("id", playerIds);
+
+          if (!cancelled && profiles) {
+            for (const profile of profiles) {
+              const info: PlayerInfo = {
+                id: profile.id,
+                displayName: profile.display_name ?? "Unknown",
+              };
+              if (profile.id === userId) {
+                setMyInfo(info);
+              } else {
+                setOpponentInfo(info);
+              }
+            }
+          }
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to load game");
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    fetchGameData();
+    return () => { cancelled = true; };
+  }, [gameId, user]);
+
+  // ── Realtime subscription ───────────────────────────────────────────
+  useEffect(() => {
+    if (!gameId || !user) return;
+    const currentUserId = user.id;
+
+    if (channelRef.current) {
+      supabase.removeChannel(channelRef.current);
+    }
+
+    const channel = supabase
+      .channel(`game:${gameId}`)
+      // New moves
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "moves",
+          filter: `game_id=eq.${gameId}`,
+        },
+        (payload) => {
+          const newMove = payload.new as Move;
+          setMoves((prev) => {
+            // Prevent duplicates
+            if (prev.some((m) => m.id === newMove.id)) return prev;
+            return [...prev, newMove];
+          });
+        }
+      )
+      // Game state changes (current_turn, status, winner_id)
+      .on(
+        "postgres_changes",
+        {
+          event: "UPDATE",
+          schema: "public",
+          table: "games",
+          filter: `id=eq.${gameId}`,
+        },
+        (payload) => {
+          const updated = payload.new as Game;
+          setGame(updated);
+        }
+      )
+      // Player state changes (ready, board)
+      .on(
+        "postgres_changes",
+        {
+          event: "UPDATE",
+          schema: "public",
+          table: "games_players",
+          filter: `game_id=eq.${gameId}`,
+        },
+        (payload) => {
+          const updated = payload.new as GamePlayer;
+          if (updated.player_id === currentUserId) {
+            setMyPlayer(updated);
+          } else {
+            setOpponentPlayer(updated);
+          }
+        }
+      )
+      .subscribe();
+
+    channelRef.current = channel;
+
+    return () => {
+      supabase.removeChannel(channel);
+      channelRef.current = null;
+    };
+  }, [gameId, user]);
+
+  // ── Submit ready (board placement) ──────────────────────────────────
+  const submitReady = useCallback(
+    async (fleet: MatchShip[]) => {
+      if (!gameId || !user || !myPlayer) return;
+
+      const boardState = convertFleetToBoard(fleet);
+
+      // Update our games_players row with board and ready flag
+      const { error: updateError } = await supabase
+        .from("games_players")
+        .update({ board: boardState, ready: true })
+        .eq("game_id", gameId)
+        .eq("player_id", user.id);
+
+      if (updateError) {
+        setError(updateError.message);
+        return;
+      }
+
+      // Check if opponent is also ready
+      const { data: players } = await supabase
+        .from("games_players")
+        .select("ready")
+        .eq("game_id", gameId);
+
+      const allReady = players && players.length === 2 && players.every((p) => p.ready);
+
+      if (allReady) {
+        // Transition game to in_progress
+        await supabase
+          .from("games")
+          .update({
+            status: "in_progress",
+            started_at: new Date().toISOString(),
+          })
+          .eq("id", gameId);
+      }
+    },
+    [gameId, user, myPlayer]
+  );
+
+  // ── Attack ──────────────────────────────────────────────────────────
+  const attack = useCallback(
+    async (row: number, col: number) => {
+      if (!gameId || !user || !game || !opponentPlayer) return;
+      if (attackingRef.current) return;
+      if (game.current_turn !== user.id) return;
+      if (game.status !== "in_progress") return;
+
+      // Check if cell already attacked
+      const alreadyAttacked = moves.some(
+        (m) => m.player_id === user.id && m.x === col && m.y === row
+      );
+      if (alreadyAttacked) return;
+
+      attackingRef.current = true;
+
+      // Resolve the attack against opponent's board
+      const opponentBoard = opponentPlayer.board;
+      const myPreviousMoves = moves
+        .filter((m) => m.player_id === user.id)
+        .map((m) => ({ x: m.x, y: m.y }));
+
+      const { result, sunkShip } = resolveAttack(
+        opponentBoard,
+        col,  // x = col
+        row,  // y = row
+        myPreviousMoves
+      );
+
+      const moveNumber = moves.length + 1;
+
+      try {
+        // INSERT move
+        const { error: moveError } = await supabase.from("moves").insert({
+          game_id: gameId,
+          player_id: user.id,
+          x: col,
+          y: row,
+          result,
+          sunk_ship: sunkShip?.type ?? null,
+          move_number: moveNumber,
+        });
+
+        if (moveError) throw new Error(moveError.message);
+
+        // If a ship was sunk, update the opponent's board JSONB
+        if (sunkShip) {
+          const updatedShips = opponentBoard.ships.map((s) =>
+            s.type === sunkShip.type ? { ...s, sunk: true } : s
+          );
+          const updatedBoard: BoardState = { ships: updatedShips };
+
+          await supabase
+            .from("games_players")
+            .update({ board: updatedBoard })
+            .eq("game_id", gameId)
+            .eq("player_id", opponentPlayer.player_id);
+
+          // Check win: all ships sunk?
+          const allMoves = [
+            ...myPreviousMoves,
+            { x: col, y: row },
+          ];
+
+          if (checkWinByMoves(opponentBoard, allMoves)) {
+            await supabase
+              .from("games")
+              .update({
+                status: "finished",
+                winner_id: user.id,
+                ended_at: new Date().toISOString(),
+              })
+              .eq("id", gameId);
+          } else {
+            // Switch turn
+            await supabase
+              .from("games")
+              .update({ current_turn: opponentPlayer.player_id })
+              .eq("id", gameId);
+          }
+        } else {
+          // No sunk ship — switch turn
+          await supabase
+            .from("games")
+            .update({ current_turn: opponentPlayer.player_id })
+            .eq("id", gameId);
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Attack failed");
+      } finally {
+        attackingRef.current = false;
+      }
+    },
+    [gameId, user, game, opponentPlayer, moves]
+  );
+
+  return {
+    gameStatus,
+    isMyTurn,
+    myBoard,
+    opponentBoard,
+    myInfo,
+    opponentInfo,
+    myPlayer,
+    winnerId,
+    loading,
+    error,
+    submitReady,
+    attack,
+  };
+}

--- a/src/lib/gameLogic.ts
+++ b/src/lib/gameLogic.ts
@@ -1,0 +1,199 @@
+import type {
+  BoardState,
+  CellState,
+  Move,
+  MoveResult,
+  Ship,
+} from "../types";
+import type { MatchShip } from "../game/shipRules";
+import { getShipType } from "../game/shipRules";
+
+export interface AttackResult {
+  result: MoveResult;
+  sunkShip: Ship | null;
+}
+
+/**
+ * Convert placement-UI fleet (MatchShip[]) to the DB BoardState format.
+ */
+export function convertFleetToBoard(fleet: MatchShip[]): BoardState {
+  return {
+    ships: fleet
+      .filter((s) => s.cells.length > 0)
+      .map((s) => ({
+        type: s.type ?? getShipType(s.size),
+        size: s.size,
+        cells: s.cells,
+        orientation: s.orientation ?? "horizontal",
+        sunk: false,
+      })),
+  };
+}
+
+/**
+ * Resolve an attack against a board.
+ * Returns hit/miss/sunk and the sunk ship (if any).
+ */
+export function resolveAttack(
+  board: BoardState,
+  x: number,
+  y: number,
+  previousMoves: Pick<Move, "x" | "y">[]
+): AttackResult {
+  // Already attacked?
+  const alreadyHit = previousMoves.some((m) => m.x === x && m.y === y);
+  if (alreadyHit) {
+    return { result: "miss", sunkShip: null };
+  }
+
+  // Check each ship
+  for (const ship of board.ships) {
+    const cellHit = ship.cells.some((c) => c.x === x && c.y === y);
+    if (cellHit) {
+      // Count existing hits on this ship (from previous moves)
+      const existingHits = ship.cells.filter((c) =>
+        previousMoves.some((m) => m.x === c.x && m.y === c.y)
+      ).length;
+
+      // +1 for the current hit
+      const totalHits = existingHits + 1;
+
+      if (totalHits >= ship.size) {
+        return { result: "sunk", sunkShip: ship };
+      }
+      return { result: "hit", sunkShip: null };
+    }
+  }
+
+  return { result: "miss", sunkShip: null };
+}
+
+/**
+ * Check if all ships on a board are sunk.
+ */
+export function checkWin(board: BoardState): boolean {
+  return board.ships.length > 0 && board.ships.every((ship) => ship.sunk);
+}
+
+/**
+ * Check win condition by counting moves against the board.
+ * More reliable than checking sunk flags since it uses actual move data.
+ */
+export function checkWinByMoves(
+  board: BoardState,
+  moves: Pick<Move, "x" | "y">[]
+): boolean {
+  if (board.ships.length === 0) return false;
+
+  return board.ships.every((ship) => {
+    const hitCount = ship.cells.filter((c) =>
+      moves.some((m) => m.x === c.x && m.y === c.y)
+    ).length;
+    return hitCount >= ship.size;
+  });
+}
+
+/**
+ * Build the opponent's grid display from our attack moves.
+ * Only shows hit/miss/sunk — never reveals ship positions.
+ */
+export function buildOpponentDisplay(
+  myMoves: Move[],
+  opponentBoard?: BoardState
+): CellState[][] {
+  const grid: CellState[][] = Array.from({ length: 10 }, () =>
+    Array.from<CellState>({ length: 10 }).fill("empty")
+  );
+
+  for (const move of myMoves) {
+    if (move.result === "sunk") {
+      grid[move.y][move.x] = "sunk";
+      // Mark all cells of the sunk ship
+      if (opponentBoard && move.sunk_ship) {
+        const ship = opponentBoard.ships.find(
+          (s) => s.type === move.sunk_ship
+        );
+        if (ship) {
+          for (const cell of ship.cells) {
+            grid[cell.y][cell.x] = "sunk";
+          }
+        }
+      }
+    } else if (move.result === "hit") {
+      // Only set to hit if not already sunk
+      if (grid[move.y][move.x] !== "sunk") {
+        grid[move.y][move.x] = "hit";
+      }
+    } else {
+      grid[move.y][move.x] = "miss";
+    }
+  }
+
+  return grid;
+}
+
+/**
+ * Build my own board display — shows ship positions plus incoming hits.
+ */
+export function buildMyDisplay(
+  boardState: BoardState,
+  incomingMoves: Move[]
+): CellState[][] {
+  const grid: CellState[][] = Array.from({ length: 10 }, () =>
+    Array.from<CellState>({ length: 10 }).fill("empty")
+  );
+
+  // Place ships
+  for (const ship of boardState.ships) {
+    for (const cell of ship.cells) {
+      grid[cell.y][cell.x] = ship.sunk ? "sunk" : "ship";
+    }
+  }
+
+  // Apply incoming hits
+  for (const move of incomingMoves) {
+    if (move.result === "hit") {
+      grid[move.y][move.x] = "hit";
+    } else if (move.result === "sunk") {
+      // Find the ship at this cell and mark all its cells as sunk
+      const ship = boardState.ships.find((s) =>
+        s.cells.some((c) => c.x === move.x && c.y === move.y)
+      );
+      if (ship) {
+        for (const cell of ship.cells) {
+          grid[cell.y][cell.x] = "sunk";
+        }
+      } else {
+        grid[move.y][move.x] = "sunk";
+      }
+    } else if (move.result === "miss") {
+      grid[move.y][move.x] = "miss";
+    }
+  }
+
+  return grid;
+}
+
+/**
+ * Create an empty 10x10 board.
+ */
+export function emptyBoard(): CellState[][] {
+  return Array.from({ length: 10 }, () =>
+    Array.from<CellState>({ length: 10 }).fill("empty")
+  );
+}
+
+/**
+ * Build a board display from a fleet (placement phase).
+ */
+export function boardFromFleet(
+  fleet: MatchShip[]
+): CellState[][] {
+  const board = emptyBoard();
+  for (const ship of fleet) {
+    for (const cell of ship.cells) {
+      board[cell.y][cell.x] = "ship";
+    }
+  }
+  return board;
+}

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -1,55 +1,27 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useParams, Link } from "react-router";
 import { BoardGrid } from "../components/game/BoardGrid";
-import { supabase } from "../lib/supabase";
+import { TurnIndicator } from "../components/game/TurnIndicator";
+import { GameEndModal } from "../components/game/GameEndModal";
 import { useAuth } from "../hooks/useAuth";
-import type { CellState, Orientation } from "../types";
+import { useGame } from "../hooks/useGame";
+import type { Orientation } from "../types";
 import {
   MAX_SHIP_COUNT,
   MIN_SHIP_COUNT,
   areCellsInBounds,
   createFleetState,
   getShipCells,
-  hasOverlap
+  getShipName,
+  hasOverlap,
 } from "../game/shipRules";
-
-function emptyBoard(): CellState[][] {
-  return Array.from({ length: 10 }, () =>
-    Array.from<CellState>({ length: 10 }).fill("empty")
-  );
-}
-
-function boardFromFleet(
-  fleet: ReturnType<typeof createFleetState>
-): CellState[][] {
-  const board = emptyBoard();
-  for (const ship of fleet) {
-    for (const cell of ship.cells) {
-      board[cell.y][cell.x] = "ship";
-    }
-  }
-  return board;
-}
-
-function demoOpponentBoard(): CellState[][] {
-  const b = emptyBoard();
-  b[1][3] = "hit";
-  b[1][4] = "hit";
-  b[3][7] = "miss";
-  b[6][2] = "miss";
-  b[9][0] = "hit";
-  return b;
-}
-
-interface PlayerInfo {
-  id: string;
-  displayName: string;
-}
+import { boardFromFleet } from "../lib/gameLogic";
 
 export function GamePage() {
   const { gameId } = useParams<{ gameId: string }>();
   const { user } = useAuth();
 
+  // ── Ship placement state ────────────────────────────────────────────
   const [shipCount, setShipCount] = useState<number>(5);
   const [fleet, setFleet] = useState(() => createFleetState(5));
   const [selectedShipId, setSelectedShipId] = useState<string>("ship-1");
@@ -57,68 +29,39 @@ export function GamePage() {
   const [orientation, setOrientation] = useState<Orientation>("horizontal");
   const [placementError, setPlacementError] = useState<string | null>(null);
   const [previewMap, setPreviewMap] = useState<Record<string, "valid" | "invalid">>({});
+  const [submittingReady, setSubmittingReady] = useState(false);
 
-  const [myBoard, setMyBoard] = useState<CellState[][]>(() =>
-    boardFromFleet(createFleetState(5))
-  );
-  const [opponentBoard, setOpponentBoard] =
-    useState<CellState[][]>(demoOpponentBoard);
+  // ── Game hook ───────────────────────────────────────────────────────
+  const {
+    gameStatus,
+    isMyTurn,
+    myBoard: gameBoardMy,
+    opponentBoard: gameBoardOpp,
+    myInfo,
+    opponentInfo,
+    myPlayer,
+    winnerId,
+    loading,
+    error,
+    submitReady,
+    attack,
+  } = useGame(gameId);
 
-  const [myInfo, setMyInfo] = useState<PlayerInfo | null>(null);
-  const [opponentInfo, setOpponentInfo] = useState<PlayerInfo | null>(null);
-  const [loading, setLoading] = useState(true);
+  // During setup, show the fleet placement board. After ready, show game boards.
+  const isSetup = gameStatus === "setup";
+  const isPlaying = gameStatus === "in_progress";
+  const isFinished = gameStatus === "finished" || gameStatus === "abandoned";
+  const allShipsPlaced = fleet.every((s) => s.cells.length > 0);
+  const isReady = myPlayer?.ready ?? false;
 
-  useEffect(() => {
-    if (!gameId || !user) return;
-    const currentUserId = user.id;
+  // Board to display for "my" side
+  const myDisplayBoard = isSetup && !isReady ? boardFromFleet(fleet) : gameBoardMy;
 
-    async function fetchPlayers() {
-      try {
-        const { data: players } = await supabase
-          .from("games_players")
-          .select("player_id")
-          .eq("game_id", gameId);
-
-        if (!players || players.length === 0) {
-          setLoading(false);
-          return;
-        }
-
-        const playerIds = players.map((p) => p.player_id);
-
-        const { data: profiles } = await supabase
-          .from("profiles")
-          .select("id, display_name")
-          .in("id", playerIds);
-
-        if (profiles) {
-          for (const profile of profiles) {
-            const info: PlayerInfo = {
-              id: profile.id,
-              displayName: profile.display_name ?? "Unknown"
-            };
-            if (profile.id === currentUserId) {
-              setMyInfo(info);
-            } else {
-              setOpponentInfo(info);
-            }
-          }
-        }
-      } catch {
-        // Header falls back to default labels.
-      } finally {
-        setLoading(false);
-      }
-    }
-
-    fetchPlayers();
-  }, [gameId, user]);
-
+  // ── Ship placement handlers ─────────────────────────────────────────
   const handleShipCountChange = (nextShipCount: number) => {
     const nextFleet = createFleetState(nextShipCount);
     setShipCount(nextShipCount);
     setFleet(nextFleet);
-    setMyBoard(boardFromFleet(nextFleet));
     setSelectedShipId("ship-1");
     setDraggedShipId(null);
     setPreviewMap({});
@@ -158,7 +101,6 @@ export function GamePage() {
           ? { ...ship, orientation, cells: candidateCells }
           : ship
       );
-      setMyBoard(boardFromFleet(nextFleet));
 
       const nextUnplaced = nextFleet.find((ship) => ship.cells.length === 0);
       setSelectedShipId(nextUnplaced?.id ?? shipId);
@@ -169,10 +111,13 @@ export function GamePage() {
   };
 
   const handleMyBoardCellClick = (row: number, col: number) => {
-    placeShipAt(selectedShipId, row, col);
+    if (isSetup && !isReady) {
+      placeShipAt(selectedShipId, row, col);
+    }
   };
 
   const handleMyBoardCellDrop = (row: number, col: number) => {
+    if (!isSetup || isReady) return;
     const shipId = draggedShipId ?? selectedShipId;
     placeShipAt(shipId, row, col);
     setDraggedShipId(null);
@@ -180,10 +125,10 @@ export function GamePage() {
   };
 
   const handleMyBoardCellDragStart = (row: number, col: number) => {
+    if (!isSetup || isReady) return;
     const shipAtCell = fleet.find((ship) =>
       ship.cells.some((cell) => cell.y === row && cell.x === col)
     );
-
     if (!shipAtCell) return;
     setSelectedShipId(shipAtCell.id);
     setDraggedShipId(shipAtCell.id);
@@ -196,6 +141,7 @@ export function GamePage() {
   };
 
   const handleMyBoardCellDragOver = (row: number, col: number) => {
+    if (!isSetup || isReady) return;
     const shipId = draggedShipId ?? selectedShipId;
     const selectedShip = fleet.find((ship) => ship.id === shipId);
     if (!selectedShip) return;
@@ -214,19 +160,30 @@ export function GamePage() {
     setPreviewMap(nextPreview);
   };
 
-  const handleOpponentCellClick = (row: number, col: number) => {
-    setOpponentBoard((prev) => {
-      const next = prev.map((r) => [...r]);
-      if (next[row][col] === "empty") {
-        next[row][col] = "miss";
-      }
-      return next;
-    });
+  // ── Ready button ────────────────────────────────────────────────────
+  const handleReady = async () => {
+    if (!allShipsPlaced || submittingReady) return;
+    setSubmittingReady(true);
+    try {
+      await submitReady(fleet);
+    } catch {
+      setPlacementError("Failed to submit board. Please try again.");
+    } finally {
+      setSubmittingReady(false);
+    }
   };
 
+  // ── Attack handler ──────────────────────────────────────────────────
+  const handleOpponentCellClick = (row: number, col: number) => {
+    if (!isMyTurn) return;
+    attack(row, col);
+  };
+
+  // ── Render ──────────────────────────────────────────────────────────
   return (
     <main className="min-h-screen bg-slate-950 text-slate-100">
       <div className="mx-auto flex max-w-5xl flex-col gap-6 px-4 py-8 sm:px-6 sm:py-12">
+        {/* Header */}
         <div className="flex items-center justify-between">
           <h1 className="text-lg sm:text-2xl font-bold flex items-center gap-2">
             {loading ? (
@@ -247,137 +204,161 @@ export function GamePage() {
           </Link>
         </div>
 
-        <section className="rounded-xl border border-slate-800 bg-slate-900 p-4 sm:p-5">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-300">
-            Ship Placement
-          </h2>
-          <p className="mt-2 text-xs text-slate-400">
-            Drag a ship onto your board (or click a ship then click a cell).
-            Choose orientation before placement.
-            Ships must stay inside the 10x10 grid and cannot overlap.
+        {/* Error banner */}
+        {error && (
+          <p className="rounded border border-red-500/40 bg-red-950/30 px-3 py-2 text-xs text-red-300">
+            {error}
           </p>
+        )}
 
-          <div className="mt-4 flex flex-wrap gap-2">
-            {fleet.map((ship) => {
-              const isPlaced = ship.cells.length > 0;
-              const isSelected = selectedShipId === ship.id;
-              return (
-                <button
-                  key={ship.id}
-                  type="button"
-                  draggable
-                  onDragStart={(event) => {
-                    setSelectedShipId(ship.id);
-                    setDraggedShipId(ship.id);
-                    event.dataTransfer.setData("text/plain", ship.id);
-                    event.dataTransfer.effectAllowed = "move";
-                    setPlacementError(null);
-                  }}
-                  onDragEnd={() => {
-                    setDraggedShipId(null);
-                    setPreviewMap({});
-                  }}
-                  onClick={() => {
-                    setSelectedShipId(ship.id);
-                    setDraggedShipId(null);
-                    setPreviewMap({});
-                    setPlacementError(null);
-                  }}
-                  className={`rounded-md border px-3 py-1.5 text-xs transition-colors ${
-                    isSelected
-                      ? "border-blue-400 bg-blue-600/20 text-blue-200"
-                      : "border-slate-700 bg-slate-800 text-slate-200 hover:border-slate-500"
-                  }`}
-                >
-                  {ship.id} (1x{ship.size}) {isPlaced ? "Placed" : "Unplaced"}
-                </button>
-              );
-            })}
+        {/* Turn indicator (only during gameplay) */}
+        {isPlaying && (
+          <TurnIndicator
+            isMyTurn={isMyTurn}
+            opponentName={opponentInfo?.displayName ?? "Opponent"}
+          />
+        )}
+
+        {/* Waiting for opponent ready (setup phase, I'm ready) */}
+        {isSetup && isReady && (
+          <div className="rounded-lg border border-blue-500/40 bg-blue-950/30 px-4 py-3 text-center text-sm text-blue-300">
+            Your fleet is locked in. Waiting for opponent to ready up...
           </div>
+        )}
 
-          <div className="mt-4 flex items-center gap-3">
-            <button
-              type="button"
-              onClick={handleRotate}
-              className="rounded border border-slate-600 bg-slate-800 px-3 py-1.5 text-xs text-slate-100 hover:border-slate-500"
-            >
-              Rotate: {orientation}
-            </button>
-            <span className="text-xs text-slate-400">Selected: {selectedShipId}</span>
-          </div>
-
-          {placementError && (
-            <p className="mt-3 rounded border border-red-500/40 bg-red-950/30 px-3 py-2 text-xs text-red-300">
-              {placementError}
+        {/* Ship placement UI (setup phase, not yet ready) */}
+        {isSetup && !isReady && (
+          <section className="rounded-xl border border-slate-800 bg-slate-900 p-4 sm:p-5">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-300">
+              Ship Placement
+            </h2>
+            <p className="mt-2 text-xs text-slate-400">
+              Drag a ship onto your board (or click a ship then click a cell).
+              Choose orientation before placement.
+              Ships must stay inside the 10x10 grid and cannot overlap.
             </p>
-          )}
-        </section>
 
+            <div className="mt-4 flex flex-wrap gap-2">
+              {fleet.map((ship) => {
+                const isPlaced = ship.cells.length > 0;
+                const isSelected = selectedShipId === ship.id;
+                return (
+                  <button
+                    key={ship.id}
+                    type="button"
+                    draggable
+                    onDragStart={(event) => {
+                      setSelectedShipId(ship.id);
+                      setDraggedShipId(ship.id);
+                      event.dataTransfer.setData("text/plain", ship.id);
+                      event.dataTransfer.effectAllowed = "move";
+                      setPlacementError(null);
+                    }}
+                    onDragEnd={() => {
+                      setDraggedShipId(null);
+                      setPreviewMap({});
+                    }}
+                    onClick={() => {
+                      setSelectedShipId(ship.id);
+                      setDraggedShipId(null);
+                      setPreviewMap({});
+                      setPlacementError(null);
+                    }}
+                    className={`rounded-md border px-3 py-1.5 text-xs transition-colors ${
+                      isSelected
+                        ? "border-blue-400 bg-blue-600/20 text-blue-200"
+                        : "border-slate-700 bg-slate-800 text-slate-200 hover:border-slate-500"
+                    }`}
+                  >
+                    {getShipName(ship.size)} (1x{ship.size}) {isPlaced ? "Placed" : "Unplaced"}
+                  </button>
+                );
+              })}
+            </div>
+
+            <div className="mt-4 flex items-center gap-3">
+              <button
+                type="button"
+                onClick={handleRotate}
+                className="rounded border border-slate-600 bg-slate-800 px-3 py-1.5 text-xs text-slate-100 hover:border-slate-500"
+              >
+                Rotate: {orientation}
+              </button>
+              <label className="flex items-center gap-2 text-xs text-slate-400">
+                Ships
+                <select
+                  value={shipCount}
+                  onChange={(e) => handleShipCountChange(Number(e.target.value))}
+                  className="rounded border border-slate-700 bg-slate-950 px-2 py-1 text-slate-100"
+                >
+                  {Array.from(
+                    { length: MAX_SHIP_COUNT - MIN_SHIP_COUNT + 1 },
+                    (_, i) => i + MIN_SHIP_COUNT
+                  ).map((count) => (
+                    <option key={count} value={count}>
+                      {count}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <span className="text-xs text-slate-400">
+                Selected: {getShipName(fleet.find((s) => s.id === selectedShipId)?.size ?? 1)}
+              </span>
+            </div>
+
+            {placementError && (
+              <p className="mt-3 rounded border border-red-500/40 bg-red-950/30 px-3 py-2 text-xs text-red-300">
+                {placementError}
+              </p>
+            )}
+
+            {/* Ready button */}
+            <div className="mt-4">
+              <button
+                type="button"
+                onClick={handleReady}
+                disabled={!allShipsPlaced || submittingReady}
+                className={`rounded-lg px-6 py-2 text-sm font-semibold transition-colors ${
+                  allShipsPlaced && !submittingReady
+                    ? "bg-emerald-600 text-white hover:bg-emerald-500"
+                    : "bg-slate-700 text-slate-400 cursor-not-allowed"
+                }`}
+              >
+                {submittingReady ? "Submitting..." : allShipsPlaced ? "Ready!" : "Place all ships first"}
+              </button>
+            </div>
+          </section>
+        )}
+
+        {/* Game boards */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-10 place-items-center">
           <BoardGrid
-            cells={myBoard}
-            interactive
+            cells={myDisplayBoard}
+            interactive={isSetup && !isReady}
             onCellClick={handleMyBoardCellClick}
             onCellDrop={handleMyBoardCellDrop}
             onCellDragOver={handleMyBoardCellDragOver}
             onCellDragStart={handleMyBoardCellDragStart}
             onCellDragEnd={handleMyBoardCellDragEnd}
-            previewMap={previewMap}
+            previewMap={isSetup && !isReady ? previewMap : undefined}
             title={myInfo?.displayName ?? "Your Fleet"}
           />
           <BoardGrid
-            cells={opponentBoard}
+            cells={gameBoardOpp}
+            interactive={isMyTurn}
             onCellClick={handleOpponentCellClick}
             title={opponentInfo?.displayName ?? "Opponent's Waters"}
           />
         </div>
 
-        <section className="rounded-xl border border-slate-800 bg-slate-900 p-4 sm:p-5">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-300">
-              Fleet Rule Validation
-            </h2>
-            <label className="flex items-center gap-2 text-sm text-slate-300">
-              Ship Count
-              <select
-                value={shipCount}
-                onChange={(e) => handleShipCountChange(Number(e.target.value))}
-                className="rounded border border-slate-700 bg-slate-950 px-2 py-1 text-slate-100"
-              >
-                {Array.from(
-                  { length: MAX_SHIP_COUNT - MIN_SHIP_COUNT + 1 },
-                  (_, i) => i + MIN_SHIP_COUNT
-                ).map((count) => (
-                  <option key={count} value={count}>
-                    {count}
-                  </option>
-                ))}
-              </select>
-            </label>
-          </div>
-
-          <p className="mt-3 text-xs text-slate-400">
-            Rule: selecting N ships creates ships of sizes 1..N.
-          </p>
-          <div className="mt-3 flex flex-wrap gap-2">
-            {fleet.map((ship) => (
-              <span
-                key={ship.id}
-                className="rounded-md border border-blue-500/30 bg-blue-950/30 px-2.5 py-1 text-xs text-blue-300"
-              >
-                {ship.id}: 1x{ship.size}
-              </span>
-            ))}
-          </div>
-        </section>
-
+        {/* Legend */}
         <div className="flex flex-wrap justify-center gap-4 text-[10px] sm:text-xs text-slate-400">
           {[
             { color: "bg-slate-800", label: "Empty" },
             { color: "bg-blue-600", label: "Ship" },
             { color: "bg-red-600", label: "Hit" },
             { color: "bg-slate-700", label: "Miss" },
-            { color: "bg-red-900", label: "Sunk" }
+            { color: "bg-red-900", label: "Sunk" },
           ].map(({ color, label }) => (
             <span key={label} className="flex items-center gap-1.5">
               <span className={`inline-block h-3 w-3 rounded-sm ${color}`} />
@@ -385,6 +366,15 @@ export function GamePage() {
             </span>
           ))}
         </div>
+
+        {/* Game end modal */}
+        {isFinished && user && (
+          <GameEndModal
+            isOpen
+            isWinner={winnerId === user.id}
+            opponentName={opponentInfo?.displayName ?? "Opponent"}
+          />
+        )}
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary

- **Attack resolution**: Clicking an opponent cell resolves hit/miss/sunk against their board JSONB, INSERTs into the `moves` table, broadcasts via Supabase Realtime to both clients, switches turns, and detects win condition.
- **Phase-based GamePage**: Refactored from a single placement view to three phases — `setup` (ship placement + Ready button), `in_progress` (interactive battle grids + turn indicator), and `finished` (game end modal).
- **New pure game logic** (`gameLogic.ts`): `resolveAttack`, `checkWin`, `convertFleetToBoard`, `buildOpponentDisplay`, `buildMyDisplay` — no React, no Supabase dependencies.
- **New `useGame` hook**: Manages game state, Realtime subscriptions (moves, game updates, player readiness), `submitReady()` for board submission, and `attack()` for firing.
- **New UI components**: `TurnIndicator` (green/amber banner) and `GameEndModal` (win/loss overlay with lobby navigation).
- **Ship naming**: Added `ShipType` and `orientation` to `MatchShip` interface; ship buttons now display real names (Carrier, Battleship, etc.) instead of `ship-1`.
- **Tech doc sync**: Updated ship size table to match implementation (Destroyer=1, Submarine=2, Cruiser=3, Battleship=4, Carrier=5).

Closes #10

## Test plan

- [ ] Both players place ships and click Ready → game transitions to `in_progress`
- [ ] Player whose turn it is can click opponent cells → hit/miss/sunk appear correctly
- [ ] Player out of turn cannot click opponent grid
- [ ] Already-attacked cells are non-interactive
- [ ] Moves appear in real-time on both boards via Realtime subscription
- [ ] When all opponent ships are sunk → game ends, modal shows winner/loser
- [ ] "Return to Lobby" button navigates correctly
- [ ] `npx tsc --noEmit` passes with no errors
- [ ] `npm run build` succeeds