### PR TITLE
feat(game): game-end stats, profile updates & ship count sync

### DIFF
--- a/src/components/game/GameEndModal.tsx
+++ b/src/components/game/GameEndModal.tsx
@@ -1,16 +1,29 @@
 import { useNavigate } from "react-router";
 import { Modal } from "../common/Modal";
 
+export interface GameStats {
+  totalMoves: number;
+  hits: number;
+  misses: number;
+  accuracy: number;
+  shipsLost: number;
+  totalShips: number;
+}
+
 interface GameEndModalProps {
   isOpen: boolean;
   isWinner: boolean;
   opponentName: string;
+  stats?: GameStats;
+  onPlayAgain?: () => void;
 }
 
 export function GameEndModal({
   isOpen,
   isWinner,
   opponentName,
+  stats,
+  onPlayAgain,
 }: GameEndModalProps) {
   const navigate = useNavigate();
 
@@ -24,16 +37,49 @@ export function GameEndModal({
         <span className="text-5xl">{isWinner ? "🎉" : "💥"}</span>
         <p className="text-center text-slate-200">
           {isWinner
-            ? `You sank all of ${opponentName}'s ships!`
+            ? `You sank all of ${opponentName}'s ships${stats ? ` in ${stats.totalMoves} moves` : ""}!`
             : `${opponentName} sank all your ships.`}
         </p>
-        <button
-          type="button"
-          onClick={() => navigate("/lobby")}
-          className="mt-2 rounded-lg bg-blue-600 px-6 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-500"
-        >
-          Return to Lobby
-        </button>
+
+        {stats && (
+          <div className="grid w-full grid-cols-2 gap-3 rounded-lg border border-slate-700 bg-slate-800/60 p-4 text-sm">
+            <div className="flex flex-col items-center">
+              <span className="text-lg font-bold text-emerald-400">{stats.hits}</span>
+              <span className="text-xs text-slate-400">Hits</span>
+            </div>
+            <div className="flex flex-col items-center">
+              <span className="text-lg font-bold text-slate-300">{stats.misses}</span>
+              <span className="text-xs text-slate-400">Misses</span>
+            </div>
+            <div className="flex flex-col items-center">
+              <span className="text-lg font-bold text-blue-400">{stats.accuracy}%</span>
+              <span className="text-xs text-slate-400">Accuracy</span>
+            </div>
+            <div className="flex flex-col items-center">
+              <span className="text-lg font-bold text-red-400">{stats.shipsLost}/{stats.totalShips}</span>
+              <span className="text-xs text-slate-400">Ships Lost</span>
+            </div>
+          </div>
+        )}
+
+        <div className="mt-2 flex gap-3">
+          {onPlayAgain && (
+            <button
+              type="button"
+              onClick={onPlayAgain}
+              className="rounded-lg bg-emerald-600 px-6 py-2 text-sm font-semibold text-white transition-colors hover:bg-emerald-500"
+            >
+              Play Again
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => navigate("/lobby")}
+            className="rounded-lg bg-blue-600 px-6 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-500"
+          >
+            Return to Lobby
+          </button>
+        </div>
       </div>
     </Modal>
   );

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -195,6 +195,31 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     };
   }, [user?.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Realtime subscription for profile updates (stats changes after game end)
+  useEffect(() => {
+    if (!user) return;
+
+    const channel = supabase
+      .channel(`profile:${user.id}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "UPDATE",
+          schema: "public",
+          table: "profiles",
+          filter: `id=eq.${user.id}`,
+        },
+        (payload) => {
+          setProfile(payload.new as Profile);
+        }
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [user?.id]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const signUp = useCallback(
     async (email: string, password: string, displayName: string) => {
       const { error } = await supabase.auth.signUp({

--- a/src/hooks/useGame.ts
+++ b/src/hooks/useGame.ts
@@ -37,14 +37,24 @@ export interface UseGameReturn {
   opponentInfo: PlayerInfo | null;
   myPlayer: GamePlayer | null;
   opponentPlayer: GamePlayer | null;
+  moves: Move[];
   winnerId: string | null;
   loading: boolean;
   error: string | null;
   connectionStatus: ConnectionStatus;
+  gameShipCount: number;
   submitReady: (fleet: MatchShip[]) => Promise<void>;
-  endPlacementTurn: (fleet: MatchShip[], shipSize: number) => Promise<void>;
+  endPlacementTurn: (fleet: MatchShip[], shipSize: number, shipCount: number) => Promise<void>;
   abandonGame: () => Promise<void>;
   attack: (row: number, col: number) => Promise<void>;
+}
+
+async function updateProfileStats(winnerId: string, loserId: string) {
+  // Atomic increment via Postgres RPC to avoid lost-update race conditions
+  await Promise.all([
+    supabase.rpc("increment_wins", { player_id: winnerId }),
+    supabase.rpc("increment_losses", { player_id: loserId }),
+  ]);
 }
 
 export function useGame(gameId: string | undefined): UseGameReturn {
@@ -68,6 +78,7 @@ export function useGame(gameId: string | undefined): UseGameReturn {
   const currentTurnPlayerId = game?.current_turn ?? null;
   const isMyTurn = game?.current_turn === user?.id && gameStatus === "in_progress";
   const winnerId = game?.winner_id ?? null;
+  const gameShipCount = game?.ship_count ?? 5;
 
   // Derive board displays from state
   const myMoves = moves.filter((m) => m.player_id === user?.id);
@@ -340,7 +351,7 @@ export function useGame(gameId: string | undefined): UseGameReturn {
   );
 
   const endPlacementTurn = useCallback(
-    async (fleet: MatchShip[], shipSize: number) => {
+    async (fleet: MatchShip[], shipSize: number, shipCount: number) => {
       if (!gameId || !user || !myPlayer || !opponentPlayer || !game) return;
       if (game.status !== "setup") return;
       if (game.current_turn !== user.id) {
@@ -357,6 +368,14 @@ export function useGame(gameId: string | undefined): UseGameReturn {
       const boardState = convertFleetToBoard(fleet);
       const placedCount = boardState.ships.length;
       const isNowReady = placedCount === fleet.length;
+
+      // Lock ship_count in DB on first placement so both players use the same count
+      if (placedCount === 1 && game.ship_count !== shipCount) {
+        await supabase
+          .from("games")
+          .update({ ship_count: shipCount })
+          .eq("id", gameId);
+      }
 
       const { error: updateError } = await supabase
         .from("games_players")
@@ -426,6 +445,11 @@ export function useGame(gameId: string | undefined): UseGameReturn {
     if (abandonError) {
       setError(abandonError.message);
       return;
+    }
+
+    // Update profile stats: abandoner loses, opponent wins
+    if (opponentPlayer?.player_id) {
+      await updateProfileStats(opponentPlayer.player_id, user.id);
     }
 
     setGame((prev) =>
@@ -522,6 +546,9 @@ export function useGame(gameId: string | undefined): UseGameReturn {
                 ended_at: new Date().toISOString(),
               })
               .eq("id", gameId);
+
+            // Update profile stats for both players
+            await updateProfileStats(user.id, opponentPlayer.player_id);
           } else {
             // Switch turn
             await supabase
@@ -555,10 +582,12 @@ export function useGame(gameId: string | undefined): UseGameReturn {
     opponentInfo,
     myPlayer,
     opponentPlayer,
+    moves,
     winnerId,
     loading,
     error,
     connectionStatus,
+    gameShipCount,
     submitReady,
     endPlacementTurn,
     abandonGame,

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from "react-router";
 import { BoardGrid } from "../components/game/BoardGrid";
 import { TurnIndicator } from "../components/game/TurnIndicator";
 import { GameEndModal } from "../components/game/GameEndModal";
+import type { GameStats } from "../components/game/GameEndModal";
 import { useAuth } from "../hooks/useAuth";
 import { useGame } from "../hooks/useGame";
 import type { Orientation } from "../types";
@@ -49,7 +50,9 @@ export function GamePage() {
     winnerId,
     loading,
     error,
+    moves: gameMoves,
     connectionStatus,
+    gameShipCount,
     endPlacementTurn,
     abandonGame,
     attack,
@@ -89,6 +92,31 @@ export function GamePage() {
     !submittingTurn;
 
   const myDisplayBoard = isSetup && !isReady ? boardFromFleet(fleet) : gameBoardMy;
+
+  const endStats = useMemo<GameStats | null>(() => {
+    if (!isFinished || !user) return null;
+    const myMoves = gameMoves.filter((m) => m.player_id === user.id);
+    const hits = myMoves.filter((m) => m.result === "hit" || m.result === "sunk").length;
+    const misses = myMoves.filter((m) => m.result === "miss").length;
+    const totalShips = myPlayer?.board?.ships?.length ?? 0;
+    const shipsLost = myPlayer?.board?.ships?.filter((s) => s.sunk).length ?? 0;
+    return {
+      totalMoves: myMoves.length,
+      hits,
+      misses,
+      accuracy: hits + misses > 0 ? Math.round((hits / (hits + misses)) * 100) : 0,
+      shipsLost,
+      totalShips,
+    };
+  }, [isFinished, user, gameMoves, myPlayer]);
+
+  // Sync local shipCount with DB value when opponent has already locked it
+  useEffect(() => {
+    if (gameShipCount !== shipCount) {
+      setShipCount(gameShipCount);
+      setFleet(createFleetState(gameShipCount));
+    }
+  }, [gameShipCount]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (!myPlayer) return;
@@ -237,7 +265,7 @@ export function GamePage() {
 
     setSubmittingTurn(true);
     try {
-      await endPlacementTurn(fleet, activeShip.size);
+      await endPlacementTurn(fleet, activeShip.size, shipCount);
       setPlacementError(null);
       setPreviewMap({});
       setDraggedShipId(null);
@@ -486,11 +514,13 @@ export function GamePage() {
           ))}
         </div>
 
-        {isFinished && user && (
+        {isFinished && user && endStats && (
           <GameEndModal
             isOpen
             isWinner={winnerId === user.id}
             opponentName={opponentInfo?.displayName ?? "Opponent"}
+            stats={endStats}
+            onPlayAgain={() => navigate("/lobby", { state: { quickMatch: true } })}
           />
         )}
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -36,6 +36,7 @@ export interface Game {
   status: GameStatus;
   current_turn: string | null;
   winner_id: string | null;
+  ship_count: number;
   created_at: string;
   started_at: string | null;
   ended_at: string | null;


### PR DESCRIPTION
## Summary
- **Game End Modal**: Stats grid showing hits, misses, accuracy %, ships lost + Play Again button
- **Profile stats**: Atomic increment via Supabase RPC (`increment_wins`, `increment_losses`) on win and abandon
- **Profile realtime**: Live profile updates via `postgres_changes` subscription on `profiles` table
- **Ship count sync**: First player's ship count selection is saved to `games.ship_count` and synced to opponent via realtime

Closes #13

## DB changes applied
- `games.ship_count` column (INTEGER, DEFAULT 5, CHECK 1-5)
- `increment_wins(player_id)` RPC function
- `increment_losses(player_id)` RPC function
- `profiles` added to `supabase_realtime` publication

## Test plan
- [x] Victory/Defeat modal shows correct stats (hits, misses, accuracy, ships lost)
- [x] Play Again and Return to Lobby buttons work
- [x] Profile wins/losses/total_games update after game end
- [x] Profile wins/losses/total_games update after abandon
- [x] Ship count syncs between players (player 1 picks 3, player 2 locked to 3)
- [x] Profile stats update in realtime without page refresh